### PR TITLE
68 cli not putting api binaries in correct folder structure when target doenst have a x86 64 processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Cargo.lock
 
 /assets/auto_generated/**
 !/assets/auto_generated/.gitkeep
+!/assets/auto_generated/binaries
 !/assets/auto_generated/binaries/.gitkeep
 /fmiapi/src/fmi2_proto.rs
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Cargo.lock
 
 /assets/auto_generated/**
 !/assets/auto_generated/.gitkeep
+!/assets/auto_generated/binaries/.gitkeep
 /fmiapi/src/fmi2_proto.rs
 
 /venv

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Building for local machine (with Windows as the example, and PowerShell commands
 5. **Windows:** Build the FMU dll using `cargo build --target x86_64-pc-windows-msvc --release`. This should build the project for your operating system, and generate the `fmiapi.dll` in the folder [target/x86_64-pc-windows-msvc/release](target/x86_64-pc-windows-msvc/release/). The dll contains the FMU headers' implementation. **Linux:** Build the FMU `so` using the toolchain of your machine, e.g., `cargo build --target x86_64-unknown-linux-gnu --release`. This generates the `libfmiapi.so` in the folder [target/x86_64-unknown-linux-gnu/release](target/x86_64-unknown-linux-gnu/release/), which contains the FMU headers' implementation.
 
 6. Generate the content for the [./assets/auto_generated/](./assets/auto_generated/) folder, that the CLI is packaged with.
-   1. Copy the binaries compiled in the previous step to the correct subfulder under [./assets/auto_generated/binaries/](./assets/auto_generated/binaries/).
+   1. Copy the binaries compiled in the previous step to the correct subfolder under [./assets/auto_generated/binaries/](./assets/auto_generated/binaries/) creating the subfolder first if it isn't already present.
       The name of the subfolder is both OS and CPU architecture dependent. It follows the naming scheme of the [FMI3 platform tuple](https://fmi-standard.org/docs/3.0.2/#platform-tuple-definition) `<arch>-<sys>`:
       **Architecture** `<arch>`
       | **Name** | **Description**         |
@@ -367,17 +367,21 @@ Building for local machine (with Windows as the example, and PowerShell commands
       | windows  | Microsoft Windows                           |
 
       Furthermore, the name of the binary after copying should be `unifmu.<extension>` where `<extension>` is the original extension of the binary.
-      **Examples**
+
+      **Examples** (run these commands from the root of the repository)
       *Windows running on Intel/AMD x86 64-bit architecture:*
       ```powershell
+      New-Item -Type dir ./assets/auto_generated/binaries/x86_64-windows
       Copy-Item -Force ./target/x86_64-pc-windows-msvc/release/fmiapi.dll ./assets/auto_generated/binaries/x86_64-windows/unifmu.dll
       ``` 
       *Linux running on Intel/AMD x86 64-bit architecture:*
       ```
-      cp target/x86_64-unknown-linux-gnu/release/libfmiapi.so assets/auto_generated/binaries/x86_64-windows/unifmu.so
+      mkdir -p assets/auto_generated/binaries/x86_64-linux
+      cp target/x86_64-unknown-linux-gnu/release/libfmiapi.so assets/auto_generated/binaries/x86_64-linux/unifmu.so
       ```
       *Darwin (macOS) running on ARM 64-bit architecture:*
       ```
+      mkdir -p assets/auto_generated/binaries/aarch64-darwin
       cp target/x86_64-unknown-linux-gnu/release/libfmiapi.dylib assets/auto_generated/binaries/aarch64-darwin/unifmu.dylib
       ```
    2. Generate the protobuf schemas for python, csharp, and java backends:

--- a/README.md
+++ b/README.md
@@ -349,13 +349,36 @@ Building for local machine (with Windows as the example, and PowerShell commands
 5. **Windows:** Build the FMU dll using `cargo build --target x86_64-pc-windows-msvc --release`. This should build the project for your operating system, and generate the `fmiapi.dll` in the folder [target/x86_64-pc-windows-msvc/release](target/x86_64-pc-windows-msvc/release/). The dll contains the FMU headers' implementation. **Linux:** Build the FMU `so` using the toolchain of your machine, e.g., `cargo build --target x86_64-unknown-linux-gnu --release`. This generates the `libfmiapi.so` in the folder [target/x86_64-unknown-linux-gnu/release](target/x86_64-unknown-linux-gnu/release/), which contains the FMU headers' implementation.
 
 6. Generate the content for the [./assets/auto_generated/](./assets/auto_generated/) folder, that the CLI is packaged with.
-   1. **Windows:** Copy the generated dll into the assets folder (needed by the CLI). **Note the change of filename.**
+   1. Copy the binaries compiled in the previous step to the correct subfulder under [./assets/auto_generated/binaries/](./assets/auto_generated/binaries/).
+      The name of the subfolder is both OS and CPU architecture dependent. It follows the naming scheme of the [FMI3 platform tuple](https://fmi-standard.org/docs/3.0.2/#platform-tuple-definition) `<arch>-<sys>`:
+      **Architecture** `<arch>`
+      | **Name** | **Description**         |
+      | -------- | ----------------------- |
+      | aarch32  | ARM 32-bit Architecture |
+      | aarch64  | ARM 64-bit Architecture |
+      | x86      | Intel/AMD x86 32-bit    |
+      | x86_64   | Intel/AMD x86 64-bit    |
+
+      **Operating system** `<sys>`
+      | **Name** | **Description**                             |
+      | -------- | ------------------------------------------- |
+      | darwin   | Darwin (macOS, iOS, watchOS, tvOS, audioOS) |
+      | linux    | Linux                                       |
+      | windows  | Microsoft Windows                           |
+
+      Furthermore, the name of the binary after copying should be `unifmu.<extension>` where `<extension>` is the original extension of the binary.
+      **Examples**
+      *Windows running on Intel/AMD x86 64-bit architecture:*
       ```powershell
-      Copy-Item -Force ./target/x86_64-pc-windows-msvc/release/fmiapi.dll ./assets/auto_generated/unifmu.dll
-      ```  
-      **Linux:** Copy the generated `so` into the assets folder (**Note the change of filename**).
+      Copy-Item -Force ./target/x86_64-pc-windows-msvc/release/fmiapi.dll ./assets/auto_generated/binaries/x86_64-windows/unifmu.dll
+      ``` 
+      *Linux running on Intel/AMD x86 64-bit architecture:*
       ```
-      cp target/x86_64-unknown-linux-gnu/release/libfmiapi.so assets/auto_generated/unifmu.so
+      cp target/x86_64-unknown-linux-gnu/release/libfmiapi.so assets/auto_generated/binaries/x86_64-windows/unifmu.so
+      ```
+      *Darwin (macOS) running on ARM 64-bit architecture:*
+      ```
+      cp target/x86_64-unknown-linux-gnu/release/libfmiapi.dylib assets/auto_generated/binaries/aarch64-darwin/unifmu.dylib
       ```
    2. Generate the protobuf schemas for python, csharp, and java backends:
       ```powershell

--- a/docker-build/build_all.sh
+++ b/docker-build/build_all.sh
@@ -13,9 +13,9 @@ export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/osxcross/target/bin/x86_64-a
 cargo build --package ${tgt} --target x86_64-apple-darwin --release
 
 echo "copying fmiapi into cli assets"
-cp target/x86_64-unknown-linux-gnu/release/lib${tgt}.so assets/auto_generated/unifmu.so
-cp target/x86_64-pc-windows-gnu/release/${tgt}.dll assets/auto_generated/unifmu.dll
-cp target/x86_64-apple-darwin/release/lib${tgt}.dylib assets/auto_generated/unifmu.dylib
+cp target/x86_64-unknown-linux-gnu/release/lib${tgt}.so assets/auto_generated/binaries/x86_64-linux/unifmu.so
+cp target/x86_64-pc-windows-gnu/release/${tgt}.dll assets/auto_generated/binaries/x86_64-windows/unifmu.dll
+cp target/x86_64-apple-darwin/release/lib${tgt}.dylib assets/auto_generated/binaries/x86/64-darwin/unifmu.dylib
 
 # ------------------------------ schemas ------------------------------
 echo "generating protobuf schemas for python, csharp, and java backends"

--- a/docker-build/build_all.sh
+++ b/docker-build/build_all.sh
@@ -13,6 +13,9 @@ export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/osxcross/target/bin/x86_64-a
 cargo build --package ${tgt} --target x86_64-apple-darwin --release
 
 echo "copying fmiapi into cli assets"
+mkdir -p assets/auto_generated/binaries/x86_64-linux
+mkdir -p assets/auto_generated/binaries/x86_64-windows
+mkdir -p assets/auto_generated/binaries/x86/64-darwin
 cp target/x86_64-unknown-linux-gnu/release/lib${tgt}.so assets/auto_generated/binaries/x86_64-linux/unifmu.so
 cp target/x86_64-pc-windows-gnu/release/${tgt}.dll assets/auto_generated/binaries/x86_64-windows/unifmu.dll
 cp target/x86_64-apple-darwin/release/lib${tgt}.dylib assets/auto_generated/binaries/x86/64-darwin/unifmu.dylib

--- a/test_local.sh
+++ b/test_local.sh
@@ -1,6 +1,6 @@
 protoc -I=./schemas --python_out=./assets/auto_generated --csharp_out=./assets/auto_generated --java_out ./assets/auto_generated fmi2_messages.proto fmi3_messages.proto unifmu_handshake.proto
 cargo build --package fmiapi --target x86_64-unknown-linux-gnu --release
-cp ./target/x86_64-unknown-linux-gnu/release/libfmiapi.so ./assets/auto_generated/unifmu.so
+cp ./target/x86_64-unknown-linux-gnu/release/libfmiapi.so ./assets/auto_generated/binaries/x86_64-linux/unifmu.so
 cargo test
 cargo run --bin unifmu --release -- generate python myfmu
 cargo run --bin unifmu --release -- generate python myfmu.fmu --zipped


### PR DESCRIPTION
CLI now infers the binaries folder structure for the generated FMU from the structure of the contents of the assets/autogenerated/binaries folder.

The README now describes how to copy the fmiapi binaries after compilation to comply with the FMI3 standard.