### PR TITLE
fixing issue #80

### DIFF
--- a/assets/common/fmi2/backend_remote_FMU.py
+++ b/assets/common/fmi2/backend_remote_FMU.py
@@ -18,6 +18,10 @@ from schemas.fmi2_messages_pb2 import (
     Fmi2GetBooleanReturn,
     Fmi2GetStringReturn,
 )
+from schemas.unifmu_handshake_pb2 import (
+    HandshakeStatus,
+    HandshakeReply,
+)
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__file__)
@@ -76,8 +80,9 @@ if __name__ == "__main__":
     logger.info(f"Socket connected successfully.")
 
     # send handshake
-    state = Fmi2EmptyReturn().SerializeToString()
-    socket.send(state)
+    handshake = HandshakeReply()
+    handshake.status = HandshakeStatus.OK
+    socket.send(handshake.SerializeToString())
 
     # dispatch commands to black-box FMU with fmpy
     command = Fmi2Command()

--- a/assets/common/fmi3/backend_remote_FMU.py
+++ b/assets/common/fmi3/backend_remote_FMU.py
@@ -31,6 +31,10 @@ from schemas.fmi3_messages_pb2 import (
     Fmi3GetIntervalDecimalReturn,
     Fmi3UpdateDiscreteStatesReturn,
 )
+from schemas.unifmu_handshake_pb2 import (
+    HandshakeStatus,
+    HandshakeReply,
+)
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__file__)
@@ -89,8 +93,9 @@ if __name__ == "__main__":
     logger.info(f"Socket connected successfully.")
 
     # send handshake
-    state = Fmi3EmptyReturn().SerializeToString()
-    socket.send(state)
+    handshake = HandshakeReply()
+    handshake.status = HandshakeStatus.OK
+    socket.send(handshake.SerializeToString())
 
     # dispatch commands to model
     command = Fmi3Command()

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -244,6 +244,10 @@ lazy_static! {
             ),
             ("python/launch.toml", "launch.toml"),
             ("python/fmi2/README.md", "README.md"),
+            (
+                "auto_generated/unifmu_handshake_pb2.py",
+                "schemas/unifmu_handshake_pb2.py"
+            ),
         ],
         fmi3_resources: vec![
             ("python/requirements.txt", "requirements.txt"),
@@ -254,6 +258,10 @@ lazy_static! {
             ),
             ("python/launch.toml", "launch.toml"),
             ("python/fmi3/README.md", "README.md"),
+            (
+                "auto_generated/unifmu_handshake_pb2.py",
+                "schemas/unifmu_handshake_pb2.py"
+            ),
         ],
     };
 }


### PR DESCRIPTION
Solves bug #80 by adding the handshake implementation of UniFMU to remote black-box FMUs.
@DisasterlyDisco, can you double check? I tested it manually with the commands described in #80 for the test suite (using normal cargo functions and then a manual execution of the proxy-model pair).